### PR TITLE
use `Buffer.alloc` instead of `new Buffer`

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -45,7 +45,7 @@ module.exports = class Gooi {
 				callback(e, null);
 			});
 
-			let buf=new Buffer(4096);
+			let buf=Buffer.alloc(4096);
 			function writechunk(){
 				const nread=fs.readSync(filedesc,buf,0,4096,null);
 				if(nread==4096)req.write(buf,writechunk);

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gooi",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"description": "Transfer files with gooi",
 	"main": "main.js",
 	"scripts": {

--- a/server/main.js
+++ b/server/main.js
@@ -114,7 +114,7 @@ app.get("/vang/:id",(req,res)=>{
 		"Content-Disposition":`attachment; filename=${fnamequo}`,
 		"Transfer-Encoding":"chunked"
 	});
-	let buf=new Buffer(4096);
+	let buf=Buffer.alloc(4096);
 	function writechunk(){
 		let nread;
 		try {nread=fs.readSync(filedesc,buf,0,4096,null);}

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gooi-server",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"description": "Server for gooi to allow for easy catching",
 	"main": "main.js",
 	"scripts": {


### PR DESCRIPTION
The constructor of `Buffer` is deprecated, see
https://nodejs.org/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe