### PR TITLE
Add readConfig function

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -5,6 +5,8 @@ const fs = require("fs");
 const path = require("path");
 const yazl = require("yazl");
 
+const parseNetrc = require('./netrc.js');
+
 function upload(gooi, stream, filename) {
 	return new Promise((resolve, reject) => {
 		const req = https.request({
@@ -117,4 +119,27 @@ module.exports = class Gooi {
 	vang(id) {
 		// TODO
 	}
-}
+};
+
+module.exports.readConfig = function readConfig (fname) {
+	if (!fname) {
+		const configsDir = process.env['XDG_CONFIG_HOME'] || `${process.env['HOME']}/.config/`;
+		fname = path.join(configsDir, 'gooi', 'config.json');
+	}
+
+	let config;
+	try {
+		config = require(fname);
+	} catch (e) {
+		throw new Error(`Could not read config file: ${e}`);
+	}
+
+	if (config.hostname == null) {
+		throw new Error('config: hostname required');
+	}
+	config.port = config.port || 443;
+	config.prefix = config.prefix || '/gooi/';
+	config = parseNetrc(config);
+
+	return config;
+};

--- a/client/netrc.js
+++ b/client/netrc.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+
+function parseNetrc(text) {
+	const result = new Map();
+	let current = null;
+
+	const lines = text.split("\n");
+	for (let i = 0; i < lines.length; i++) {
+		if (lines[i].match(/^\s*$/)) continue;
+		const m = lines[i].match(/^\s*(\S+)\s+(.*)$/);
+		if (!m) {
+			console.error(`Unrecognised line in netrc at line ${i+1}`);
+			process.exit(1);
+		}
+
+		const key = m[1];
+		const value = m[2];
+		switch (key) {
+			case "machine":
+				current = {login: null, password: null};
+				result.set(value, current);
+				break;
+			case "login":
+			case "password":
+				current[key] = value;
+				break;
+			default:
+				console.error(`Unrecognised key in netrc at line ${i+1}`);
+				process.exit(1);
+		}
+	}
+
+	return result;
+}
+
+module.exports = function (config) {
+	if (config.netrc == null) {
+		return config;
+	}
+
+	const credentials = parseNetrc(fs.readFileSync(config.netrc).toString()).get(config.hostname);
+	if (credentials != null) {
+		config.auth = credentials.login + ":" + credentials.password;
+	}
+	delete config.netrc;
+
+	return config;
+}

--- a/client/netrc.js
+++ b/client/netrc.js
@@ -9,8 +9,7 @@ function parseNetrc(text) {
 		if (lines[i].match(/^\s*$/)) continue;
 		const m = lines[i].match(/^\s*(\S+)\s+(.*)$/);
 		if (!m) {
-			console.error(`Unrecognised line in netrc at line ${i+1}`);
-			process.exit(1);
+			throw new Error(`Unrecognised line in netrc at line ${i+1}`);
 		}
 
 		const key = m[1];
@@ -25,8 +24,7 @@ function parseNetrc(text) {
 				current[key] = value;
 				break;
 			default:
-				console.error(`Unrecognised key in netrc at line ${i+1}`);
-				process.exit(1);
+				throw new Error(`Unrecognised key in netrc at line ${i+1}`);
 		}
 	}
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gooi",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gooi",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"description": "Transfer files with gooi",
 	"main": "main.js",
 	"scripts": {


### PR DESCRIPTION
This function handles netrc reading, remove that from the bin code.

This commit also removes support for the deprecated `url` field, we've
gone to 2.0.0, it's fine to remove the support for it now.