### PR TITLE
server: Deduplicate files using hard links and in-memory hash cache

### DIFF
--- a/server/main.js
+++ b/server/main.js
@@ -312,7 +312,7 @@ app.get("/vang/:id/:fname", idMiddleware, (req, res) => {
 
 app.post("/houvast/:id", idMiddleware, (req, res) => {
 	try {
-		const fd = fs.openSync(`${FILES_DIRNAME}/${req.id}`, "a");
+		const fd = fs.openSync(`${FILES_DIRNAME}/${req.id}-fname`, "a");
 		const now = new Date();
 		fs.futimesSync(fd, now, now);
 		fs.closeSync(fd);


### PR DESCRIPTION
Title. Tries to do a number of things asynchronously, including the hashing of existing files upon server startup. While there may be some missed deduplication opportunities due to this, it shouldn't actually break anything.

It's quite unfortunate that link(2) doesn't support atomically overwriting the target in case it already exists; this forces a rename-link-unlink dance in `dedupNewFile()` that feels fragile.